### PR TITLE
feat: add zod to github api and change versions structure, default to the latest version

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,18 +16,16 @@ export const getT3Versions = async () => {
     "https://api.github.com/repos/t3-oss/create-t3-app/releases"
   );
 
-  const regexForVersion = /^create-t3-app@\d+\.\d+\.\d+$/;
-
-  const responseSchema = z.array(
-    z.object({ tag_name: z.string().regex(regexForVersion) })
-  );
+  const responseSchema = z.array(z.object({ tag_name: z.string() }));
   const parsed = responseSchema.safeParse(await response.json());
 
   if (!parsed.success) {
     return [];
   }
 
-  return parsed.data.map((release) => release.tag_name.split("@")[1] ?? "");
+  return parsed.data
+    .map((release) => release.tag_name.split("@")[1] ?? "")
+    .filter((v) => v !== "");
 };
 
 export const getT3VersionsGroupedByMajor = async () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,14 +16,12 @@ export const getT3Versions = async () => {
     "https://api.github.com/repos/t3-oss/create-t3-app/releases"
   );
 
-  const json = await response.json();
-
   const regexForVersion = /^create-t3-app@\d+\.\d+\.\d+$/;
 
   const responseSchema = z.array(
     z.object({ tag_name: z.string().regex(regexForVersion) })
   );
-  const parsed = responseSchema.safeParse(json);
+  const parsed = responseSchema.safeParse(await response.json());
 
   if (!parsed.success) {
     return [];
@@ -120,7 +118,7 @@ export const arrangements = (array: string[]) => {
   for (const element of array) {
     const length = result.length;
     for (let i = 0; i < length; i++) {
-      const subset = result[i]!.slice();
+      const subset = result[i]?.slice() ?? [];
       subset.push(element);
       result.push(subset);
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -53,7 +53,9 @@ export const getT3VersionsGroupedByMajor = async () => {
     }
   });
 
-  return versionsGroupedByMajor;
+  return versionsGroupedByMajor.sort(
+    (a, b) => Number(b.major) - Number(a.major)
+  );
 };
 
 export interface Features {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,7 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/Select";
 import {
-  Features,
+  type Features,
   getT3VersionsGroupedByMajor,
   type VersionsGroupedByMajor,
 } from "@/lib/utils";
@@ -74,7 +74,7 @@ const Home: NextPage = () => {
     // if only one major version is available and it has no versions, return empty object
     if (
       filteredVersions.length === 1 &&
-      filteredVersions[0]!.versions.length === 0
+      (filteredVersions[0]?.versions.length ?? []) === 0
     )
       return [];
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,12 +19,12 @@ import Image from "next/image";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 
-const Home: NextPage = () => {
+const UpgradePanel: React.FC<{
+  loading: boolean;
+  versionOptions: VersionsGroupedByMajor;
+}> = ({ loading, versionOptions }) => {
   const router = useRouter();
 
-  const [versionOptions, setVersionOptions] = useState<VersionsGroupedByMajor>(
-    []
-  );
   const [currentVersion, setCurrentVersion] = useState<string | null>(null);
   const [upgradeVersion, setUpgradeVersion] = useState<string | null>(null);
   const [features, setFeatures] = useState<Features>({
@@ -81,15 +81,6 @@ const Home: NextPage = () => {
     return filteredVersions;
   }, [currentVersion, versionOptions]);
 
-  useEffect(() => {
-    const loadT3Versions = async () => {
-      const t3Versions = await getT3VersionsGroupedByMajor();
-      setVersionOptions(t3Versions);
-    };
-
-    void loadT3Versions();
-  }, []);
-
   const renderSelectContent = (options: VersionsGroupedByMajor) => {
     if (!options.length) return null;
 
@@ -123,6 +114,99 @@ const Home: NextPage = () => {
     void router.push(url);
   };
 
+  if (loading) return <span className="text-white">Loding versions...</span>;
+
+  return (
+    <>
+      <div className="flex items-center gap-6">
+        <div>
+          <p className="text-xl text-white">Current version:</p>
+          <Select onValueChange={(value) => setCurrentVersion(value)}>
+            <SelectTrigger className="w-[180px] text-white">
+              <SelectValue placeholder="Select version" />
+            </SelectTrigger>
+            <SelectContent>{renderSelectContent(versionOptions)}</SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <p className="text-xl text-white">Upgrade to:</p>
+
+          <Select
+            onValueChange={(value) => setUpgradeVersion(value)}
+            disabled={!!noUpgradeAvailable}
+            defaultValue={
+              noUpgradeAvailable
+                ? undefined
+                : upgradeVersionOptions[0]!.versions[0]
+            }
+          >
+            <SelectTrigger className="w-[180px] text-white">
+              <SelectValue
+                placeholder={
+                  noUpgradeAvailable ? "No upgrade available" : "Select version"
+                }
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {renderSelectContent(upgradeVersionOptions)}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-6 text-white">
+        {Object.keys(features).map((feature) => (
+          <div className="flex items-center space-x-4" key={feature}>
+            <Checkbox
+              id={feature}
+              checked={features[feature as keyof typeof features]}
+              onCheckedChange={(value) =>
+                value !== "indeterminate"
+                  ? setFeatures((prev) => ({
+                      ...prev,
+                      [feature]: value,
+                    }))
+                  : null
+              }
+            />
+            <label
+              htmlFor={feature}
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              {feature}
+            </label>
+          </div>
+        ))}
+      </div>
+
+      <button
+        className="rounded-md bg-[hsl(280,100%,70%)] px-4 py-2 text-lg font-medium text-white disabled:cursor-not-allowed disabled:opacity-70"
+        disabled={!currentVersion || !upgradeVersion}
+        onClick={() => goToDiff()}
+      >
+        Upgrade
+      </button>
+    </>
+  );
+};
+
+const Home: NextPage = () => {
+  const [loading, setLoading] = useState(true);
+  const [versionOptions, setVersionOptions] = useState<VersionsGroupedByMajor>(
+    []
+  );
+
+  useEffect(() => {
+    const loadT3Versions = async () => {
+      const t3Versions = await getT3VersionsGroupedByMajor();
+      setVersionOptions(t3Versions);
+      setLoading(false);
+    };
+
+    void loadT3Versions();
+  }, []);
+
   return (
     <>
       <Head>
@@ -135,74 +219,8 @@ const Home: NextPage = () => {
           <h1 className="text-center text-5xl font-extrabold tracking-tight text-white sm:text-[5rem]">
             Upgrade <span className="text-[hsl(280,100%,70%)]">T3</span> App
           </h1>
-          <div className="flex items-center gap-6">
-            <div>
-              <p className="text-xl text-white">Current version:</p>
-              <Select onValueChange={(value) => setCurrentVersion(value)}>
-                <SelectTrigger className="w-[180px] text-white">
-                  <SelectValue placeholder="Select version" />
-                </SelectTrigger>
-                <SelectContent>
-                  {renderSelectContent(versionOptions)}
-                </SelectContent>
-              </Select>
-            </div>
 
-            <div>
-              <p className="text-xl text-white">Upgrade to:</p>
-
-              <Select
-                onValueChange={(value) => setUpgradeVersion(value)}
-                disabled={!!noUpgradeAvailable}
-              >
-                <SelectTrigger className="w-[180px] text-white">
-                  <SelectValue
-                    placeholder={
-                      noUpgradeAvailable
-                        ? "No upgrade available"
-                        : "Select version"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {renderSelectContent(upgradeVersionOptions)}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-6 text-white">
-            {Object.keys(features).map((feature) => (
-              <div className="flex items-center space-x-4" key={feature}>
-                <Checkbox
-                  id={feature}
-                  checked={features[feature as keyof typeof features]}
-                  onCheckedChange={(value) =>
-                    value !== "indeterminate"
-                      ? setFeatures((prev) => ({
-                          ...prev,
-                          [feature]: value,
-                        }))
-                      : null
-                  }
-                />
-                <label
-                  htmlFor={feature}
-                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                >
-                  {feature}
-                </label>
-              </div>
-            ))}
-          </div>
-
-          <button
-            className="rounded-md bg-[hsl(280,100%,70%)] px-4 py-2 text-lg font-medium text-white disabled:cursor-not-allowed disabled:opacity-70"
-            disabled={!currentVersion || !upgradeVersion}
-            onClick={() => goToDiff()}
-          >
-            Upgrade
-          </button>
+          <UpgradePanel loading={loading} versionOptions={versionOptions} />
         </div>
         <div className="pb-5">
           <a href="https://github.com/andreifilip123/t3-upgrade-web">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,13 +40,13 @@ const UpgradePanel: React.FC<{
 
     // filter out versions that are older than the current version
     const filteredVersions = versionOptions
-      .filter((version) => Number(version.major) >= Number(major))
-      .reduce<VersionsGroupedByMajor>((acc, version) => {
-        if (Number(version.major) === Number(major)) {
+      .filter((option) => Number(option.major) >= Number(major))
+      .reduce<VersionsGroupedByMajor>((acc, option) => {
+        if (Number(option.major) === Number(major)) {
           acc.push({
-            major: version.major,
+            major: option.major,
             versions: (
-              versionOptions.find((v) => v.major === version.major)?.versions ??
+              versionOptions.find((v) => v.major === option.major)?.versions ??
               []
             ).filter((version) => {
               const [, versionMinor, versionPatch] = version.split(".");
@@ -61,9 +61,9 @@ const UpgradePanel: React.FC<{
           });
         } else {
           acc.push({
-            major: version.major,
+            major: option.major,
             versions:
-              versionOptions.find((v) => v.major === version.major)?.versions ??
+              versionOptions.find((v) => v.major === option.major)?.versions ??
               [],
           });
         }
@@ -85,11 +85,11 @@ const UpgradePanel: React.FC<{
     if (!options.length) return null;
 
     return options
-      .filter((version) => version.versions.length > 0)
-      .map((version) => (
-        <SelectGroup key={version.major}>
-          <SelectLabel>{`${version.major}.x`}</SelectLabel>
-          {version.versions.map((minorVersion) => (
+      .filter((option) => option.versions.length > 0)
+      .map((option) => (
+        <SelectGroup key={option.major}>
+          <SelectLabel>{`${option.major}.x`}</SelectLabel>
+          {option.versions.map((minorVersion) => (
             <SelectItem key={minorVersion} value={minorVersion}>
               {minorVersion}
             </SelectItem>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -132,7 +132,7 @@ const Home: NextPage = () => {
       </Head>
       <main className="flex h-screen flex-col items-center justify-center bg-gradient-to-b from-[#2e026d] to-[#15162c]">
         <div className="container flex grow flex-col items-center justify-center gap-12 px-4 py-16">
-          <h1 className="text-5xl font-extrabold tracking-tight text-white sm:text-[5rem]">
+          <h1 className="text-center text-5xl font-extrabold tracking-tight text-white sm:text-[5rem]">
             Upgrade <span className="text-[hsl(280,100%,70%)]">T3</span> App
           </h1>
           <div className="flex items-center gap-6">


### PR DESCRIPTION
### Changelog
- adds zod validation for github releases response
- changes versions type: I feel like working on object keys/values is far less readable than having an array of `{ major: string; versions: string[] }` objects, so I changed it
- fixes text centering on smaller screens (screenshot shows the current broken version)
- **defaults to the latest version** (closes #10)
- **sorts major versions** (closes #11)

![Screenshot from 2023-04-16 17-31-00](https://user-images.githubusercontent.com/53144702/232323708-56547e5e-0dc7-43a1-aa7b-f5b92a2fa992.png)
